### PR TITLE
Added possibility to manually set serial port

### DIFF
--- a/source_files/dps5005_limits.ini
+++ b/source_files/dps5005_limits.ini
@@ -4,7 +4,7 @@ if threshold exceeded value defaults to zero:
 This file may be adapted for other versions of 'DPSxxxx' power supplies:
 
 [SectionOne]
-port: "/dev/cu.wchusbserial1410" # leave empty for automatic port scanning or set serial port e.g. "/dev/cu.wchusbserial1410"
+port: "" # leave empty for automatic port scanning or set serial port e.g. "/dev/cu.wchusbserial1410"
 voltage_set_max: 50.0
 voltage_set_min: 0.0
 current_set_max: 5.0

--- a/source_files/dps5005_limits.ini
+++ b/source_files/dps5005_limits.ini
@@ -4,6 +4,7 @@ if threshold exceeded value defaults to zero:
 This file may be adapted for other versions of 'DPSxxxx' power supplies:
 
 [SectionOne]
+port: "/dev/cu.wchusbserial1410" # leave empty for automatic port scanning or set serial port e.g. "/dev/cu.wchusbserial1410"
 voltage_set_max: 50.0
 voltage_set_min: 0.0
 current_set_max: 5.0


### PR DESCRIPTION
I had some problems with the port scanning on my Mac. The scanning stopped after the first serial port and did not continue scanning.
Nevertheless, I have 12 permanent serial ports due to Bluetooth device like headphones etc. Therefore, the scanning process is probably quite long.

I added the possibility to set the desired serial port in the .ini file, which automatically disables the port scanning.

The program runs with this modification via USB fine on my Mac. Thanks for your work!
